### PR TITLE
fix: move custom params to below language

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,7 +49,8 @@ languageCode = "am"
 [Languages.ar]
 languageName = "العربية"
 languageCode = "ar"
-writingDirection = "rtl"
+    [Languages.ar.params]
+        writingDirection = "rtl"
 
 [Languages.bn]
 languageName = "Bengali"
@@ -115,7 +116,9 @@ languageCode = "it"
 [Languages.iw]
 languageName = "עברית"
 languageCode = "iw"
-writingDirection = "rtl"
+    [Languages.iw.params]
+        writingDirection = "rtl"
+
 
 [Languages.ja]
 languageName = "日本語"
@@ -188,4 +191,6 @@ languageCode = "zh-cn"
 [Languages.fa-IR]
 languageName = "فارسی"
 languageCode = "fa-IR"
-writingDirection = "rtl"
+    [Languages.fa-IR.params]
+        writingDirection = "rtl"
+        


### PR DESCRIPTION
# Contributor Covenant Adoption
In the new Hugo version, custom parameters have been relocated under the language settings, accessible via the `Languages.**.params` parameter.

## Project name
GophersBaku
## Project repository
https://github.com/gophersbaku

## Link to code of conduct in your project's repo or documentation
[Code of conduct] https://github.com/gophersbaku/community?tab=coc-ov-file


*Thank you!*
